### PR TITLE
fix: dependabot alert #24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "tailwindcss": "^3.3.6",
         "tslib": "^2.4.1",
         "typescript": "^5.0.0",
-        "vite": "^5.4.12",
+        "vite": "^5.4.19",
         "vitest": "^1.6.1",
         "vitest-mock-extended": "^1.3.1"
       },
@@ -7151,9 +7151,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.12.tgz",
-      "integrity": "sha512-KwUaKB27TvWwDJr1GjjWthLMATbGEbeWYZIbGZ5qFIsgPP3vWzLu4cVooqhm5/Z2SPDUMjyPVjTztm5tYKwQxA==",
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 		"tailwindcss": "^3.3.6",
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",
-		"vite": "^5.4.12",
+		"vite": "^5.4.19",
 		"vitest": "^1.6.1",
 		"vitest-mock-extended": "^1.3.1"
 	},


### PR DESCRIPTION
Vite's server.fs.deny bypassed with /. for files under project root

Update vite to patched version 5.4.19